### PR TITLE
Emit sorting event

### DIFF
--- a/src/columns.js
+++ b/src/columns.js
@@ -280,7 +280,7 @@ export class Columns {
         dt.sorting = true
         
         if (!init) {
-          dt.emit("datatable.sorting", column, dir)
+            dt.emit("datatable.sorting", column, dir)
         }
 
         let rows = dt.data


### PR DESCRIPTION
Emit a sorting event when sorting begins. For large datasets there is a delay between click and the sort event. This event can be used to fill that time with some UI/UX.