### PR TITLE
Add functional filters

### DIFF
--- a/demo/umd.html
+++ b/demo/umd.html
@@ -134,7 +134,7 @@
                      "Caleb X. Finch",
 	                 "Assistant",
                      "Elit Associates",
-                     "3629",
+                     "7079",
                      "09/19/2016",
                      "condimentum@eleifend.com",
                      "056 1551 7431"
@@ -145,7 +145,10 @@
          document.body.appendChild(t);
          const config = {
              data,
-             filters: {"Job": ["Assistant", "Manager"]},
+             filters: {"Job": ["Assistant", "Manager"],
+                       "Email": [e => e.endsWith('.edu'), e => e.endsWith('.com')],
+                       "Ext.": [e => e > 6000]},
+
              columns: [{ select: 4, type: 'date', format: 'MM/DD/YYYY' }]
          };
          const dt = new simpleDatatables.DataTable(t, config);


### PR DESCRIPTION
With this patch, one is able to define a filter as a boolean function.
Thus a filter might be a string (so it works as before) or a function.

Just like before, the function is hooked to a single column.
The filtering function is given a single argument that is the value of a cell.

The function is applied to every row and the table retains only those which the filter returned a truthy value.

For now, the filters do not influence on each other, that is, they are applied to all the data and not only on those visible by the user, which might give some strange behavior at first glance.