### PR TITLE
fix(dayjs): add custom parse format

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -16,23 +16,23 @@ export const parseDate = (content, format) => {
 
     if (format) {
         switch (format) {
-            case "ISO_8601":
-                // ISO8601 is already lexiographically sorted, so we can just sort it as a string.
-                date = content
-                break
-            case "RFC_2822":
-                date = dayjs(content, "ddd, MM MMM YYYY HH:mm:ss ZZ").format("YYYYMMDD")
-                break
-            case "MYSQL":
-                date = dayjs(content, "YYYY-MM-DD hh:mm:ss").format("YYYYMMDD")
-                break
-            case "UNIX":
-                date = dayjs(content).unix()
-                break
-            // User defined format using the data-format attribute or columns[n].format option
-            default:
-                date = dayjs(content, format).format("YYYYMMDD")
-                break
+        case "ISO_8601":
+            // ISO8601 is already lexiographically sorted, so we can just sort it as a string.
+            date = content
+            break
+        case "RFC_2822":
+            date = dayjs(content, "ddd, MM MMM YYYY HH:mm:ss ZZ").format("YYYYMMDD")
+            break
+        case "MYSQL":
+            date = dayjs(content, "YYYY-MM-DD hh:mm:ss").format("YYYYMMDD")
+            break
+        case "UNIX":
+            date = dayjs(content).unix()
+            break
+        // User defined format using the data-format attribute or columns[n].format option
+        default:
+            date = dayjs(content, format).format("YYYYMMDD")
+            break
         }
     }
 

--- a/src/date.js
+++ b/src/date.js
@@ -1,4 +1,7 @@
 import dayjs from "dayjs"
+import customParseFormat from "dayjs/plugin/customParseFormat"
+
+dayjs.extend(customParseFormat)
 
 /**
  * Use dayjs to parse cell contents for sorting
@@ -13,23 +16,23 @@ export const parseDate = (content, format) => {
 
     if (format) {
         switch (format) {
-        case "ISO_8601":
-            // ISO8601 is already lexiographically sorted, so we can just sort it as a string.
-            date = content
-            break
-        case "RFC_2822":
-            date = dayjs(content, "ddd, MM MMM YYYY HH:mm:ss ZZ").format("YYYYMMDD")
-            break
-        case "MYSQL":
-            date = dayjs(content, "YYYY-MM-DD hh:mm:ss").format("YYYYMMDD")
-            break
-        case "UNIX":
-            date = dayjs(content).unix()
-            break
+            case "ISO_8601":
+                // ISO8601 is already lexiographically sorted, so we can just sort it as a string.
+                date = content
+                break
+            case "RFC_2822":
+                date = dayjs(content, "ddd, MM MMM YYYY HH:mm:ss ZZ").format("YYYYMMDD")
+                break
+            case "MYSQL":
+                date = dayjs(content, "YYYY-MM-DD hh:mm:ss").format("YYYYMMDD")
+                break
+            case "UNIX":
+                date = dayjs(content).unix()
+                break
             // User defined format using the data-format attribute or columns[n].format option
-        default:
-            date = dayjs(content, format).format("YYYYMMDD")
-            break
+            default:
+                date = dayjs(content, format).format("YYYYMMDD")
+                break
         }
     }
 


### PR DESCRIPTION
If the dayjs parsing option will be used `customParseFormat` plugin must be imported.

See here: https://day.js.org/docs/en/parse/string-format

Here is a small demo on Codepen.
https://codepen.io/rema/pen/oNbvLjQ

This should be the main problem people are having with sorting dates. Because custom formats currently don't work.

Note for issue #62.
The problem of removing the spaces and comas will stand but the parsing will work for the changed format (`MMMMDYYYY`)