### PR TITLE
Add ability to set HTML Element to nextText, pre…

### DIFF
--- a/src/datatable.js
+++ b/src/datatable.js
@@ -597,7 +597,7 @@ export class DataTable {
 
         // Pager(s) / sorting
         this.wrapper.addEventListener("click", e => {
-            const t = e.target
+            const t = e.target.closest('a')
             if (t.nodeName.toLowerCase() === "a") {
                 if (t.hasAttribute("data-page")) {
                     this.page(t.getAttribute("data-page"))


### PR DESCRIPTION
Problem: Can't set HTML Element to prevText and nextText. Doing it breaks cancelling default behavior (preventDefault) for pagination links.

This pull request add ability to set html element to prevText and nextText. For example, you would like to set custom font icon or svg icon.