### PR TITLE
Update datatable.js to fix a small bug when element.closest() does not find a target

### DIFF
--- a/src/datatable.js
+++ b/src/datatable.js
@@ -598,7 +598,7 @@ export class DataTable {
         // Pager(s) / sorting
         this.wrapper.addEventListener("click", e => {
             const t = e.target.closest('a')
-            if (t.nodeName.toLowerCase() === "a") {
+            if (t && (t.nodeName.toLowerCase() === "a")) {
                 if (t.hasAttribute("data-page")) {
                     this.page(t.getAttribute("data-page"))
                     e.preventDefault()


### PR DESCRIPTION
A small bug has been identified.  The .closest function can return null if the (background) wrapper is clicked.  Add an additional check that we did find an 'a' node.  This only happens if the CSS gives access to the div and someone misses the buttons (I managed to do this :-) ).