### PR TITLE
Fix pagination list markup

### DIFF
--- a/src/datatable.js
+++ b/src/datatable.js
@@ -333,19 +333,21 @@ export class DataTable {
         this.table.classList.add("dataTable-table")
 
         // Paginator
-        const w = createElement("div", {
+        const paginatorWrapper = createElement("nav", {
             class: "dataTable-pagination"
         })
-        const paginator = createElement("ul")
-        w.appendChild(paginator)
+        const paginator = createElement("ul", {
+            class: "dataTable-pagination-list"
+        })
+        paginatorWrapper.appendChild(paginator)
 
         // Pager(s) placement
-        template = template.replace(/\{pager\}/g, w.outerHTML)
+        template = template.replace(/\{pager\}/g, paginatorWrapper.outerHTML)
         this.wrapper.innerHTML = template
 
         this.container = this.wrapper.querySelector(".dataTable-container")
 
-        this.pagers = this.wrapper.querySelectorAll(".dataTable-pagination")
+        this.pagers = this.wrapper.querySelectorAll(".dataTable-pagination-list")
 
         this.label = this.wrapper.querySelector(".dataTable-info")
 

--- a/src/style.css
+++ b/src/style.css
@@ -11,12 +11,16 @@
 	padding: 8px 10px;
 }
 
+.dataTable-top > nav:first-child,
 .dataTable-top > div:first-child,
+.dataTable-bottom > nav:first-child,
 .dataTable-bottom > div:first-child {
 	float: left;
 }
 
+.dataTable-top > nav:last-child,
 .dataTable-top > div:last-child,
+.dataTable-bottom > nav:last-child,
 .dataTable-bottom > div:last-child {
 	float: right;
 }


### PR DESCRIPTION
Pagination ul element was being created, but never used because the query selector was targeting the parent. As seen on #71 , this would result in this code:
```html
<div class="dataTable-pagination">
    <li class="pager"><a href="#" data-page="1">‹</a></li>
    <li class="active"><a href="#" data-page="1">1</a></li>
    <li class=""><a href="#" data-page="2">2</a></li>
    <li class="pager"><a href="#" data-page="2">›</a></li>
</div>
```

This PR changes the query selector target to be the ul element.
Also changes the wrapper of the pagination ul element to be nav instead of div.

Closes #71 