### PR TITLE
Set empty state if filtering yields no rows

### DIFF
--- a/src/columns.js
+++ b/src/columns.js
@@ -304,7 +304,7 @@ export class Columns {
         dt.data = filteredRows
 
         if (!dt.data.length) {
-            dt.wrapper.classList.remove("search-results")
+            dt.clear()
             dt.setMessage(dt.options.labels.noRows)
         } else {
             this.rebuild()

--- a/src/columns.js
+++ b/src/columns.js
@@ -302,8 +302,15 @@ export class Columns {
         })
 
         dt.data = filteredRows
-        this.rebuild()
-        dt.update()
+
+        if (!dt.data.length) {
+            dt.wrapper.classList.remove("search-results")
+            dt.setMessage(dt.options.labels.noRows)
+        } else {
+            this.rebuild()
+            dt.update()
+        }
+
         if (!init) {
             dt.emit("datatable.sort", column, dir)
         }


### PR DESCRIPTION
This modification expands the flexibility of the `filter` method, allowing filtering operations with inputs that yield no rows.