### PR TITLE
Set DataTable.hasRows to false for filter actions with no results

### DIFF
--- a/src/columns.js
+++ b/src/columns.js
@@ -305,6 +305,7 @@ export class Columns {
 
         if (!dt.data.length) {
             dt.clear()
+            dt.hasRows = false
             dt.setMessage(dt.options.labels.noRows)
         } else {
             this.rebuild()


### PR DESCRIPTION
Before `Columns.filter` calls `DataTable.setMessage` to set a no-row state, `DataTable.hasRows` needs to be updated to `false`.

Doing so prevents `DataTable.setMessage` from raising a `TypeError: data[0] is undefined`.

Related to #103 