### PR TITLE
Search no results label

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -35,7 +35,8 @@ export const defaultConfig = {
     labels: {
         placeholder: "Search...", // The search input placeholder
         perPage: "{select} entries per page", // per-page dropdown label
-        noRows: "No entries found", // Message shown when there are no search results
+        noRows: "No entries found", // Message shown when there are no records to show
+        noResults: "No results match your search query", // Message shown when there are no search results
         info: "Showing {start} to {end} of {rows} entries" //
     },
 

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -929,7 +929,7 @@ export class DataTable {
         if (!this.searchData.length) {
             this.wrapper.classList.remove("search-results")
 
-            this.setMessage(this.options.labels.noRows)
+            this.setMessage(this.options.labels.noResults)
         } else {
             this.update()
         }


### PR DESCRIPTION
Allow for different labels to be shown for when there are no records and when there are no search results available.