### PR TITLE
Added double quotes compatibility

### DIFF
--- a/src/datatable.js
+++ b/src/datatable.js
@@ -1295,7 +1295,8 @@ export class DataTable {
         const defaults = {
             // csv
             lineDelimiter: "\n",
-            columnDelimiter: ","
+            columnDelimiter: ",",
+            removeDoubleQuotes: false,
         }
 
         // Check for the options object
@@ -1322,7 +1323,9 @@ export class DataTable {
 
                     if (options.headings) {
                         obj.headings = rows[0].split(options.columnDelimiter)
-
+                        if (options.removeDoubleQuotes) {
+                            obj.headings = obj.headings.map(e => e.trim().replace(/(^"|"$)/g, ''))
+                        }
                         rows.shift()
                     }
 
@@ -1334,6 +1337,9 @@ export class DataTable {
 
                         if (values.length) {
                             values.forEach(value => {
+                                if (options.removeDoubleQuotes) {
+                                    value = value.trim().replace(/(^"|"$)/g, '')
+                                }
                                 obj.data[i].push(value)
                             })
                         }


### PR DESCRIPTION
**Problem:**
Some CSV use double quotes to enclose the text with special characters.

`
"SESION, 2001 ","Example","2001"

"SESION 313, 2001 ","Example","2001"
`

**Solution:**
Added a new boolean parameter to import method in order to indicate if is required remove double quotes at start and end of values.

Added an if condition to validate new parameter and removed double quotes if it is necesary.

Actual:
```javascript
dataTable.import({
    type: "csv",
    data: response,
    headings: true,
    lineDelimiter:  "\n",
    columnDelimiter:  ","
});
```
![Selección_075](https://user-images.githubusercontent.com/283008/160163475-88325e19-fda8-441e-8d37-5973143fc78e.png)

New behavior:
```javascript
dataTable.import({
    type: "csv",
    data: response,
    headings: true,
    lineDelimiter:  "\n",
    columnDelimiter:  ",",
    removeDoubleQuotes: true
});
```
![Selección_076](https://user-images.githubusercontent.com/283008/160163543-c66da7af-8ed4-4e58-879d-a071f375119a.png)
