### PR TITLE
TypeScript: Allow dom-element in typed constructor as implementation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare module "simple-datatables"{
      */
     class DataTable {
         
-        constructor(table: string, option?: object);
+        constructor(table: string | HTMLElement, option?: object);
         /**Returns a reference to the HTMLTableElement. */
         table:HTMLElement;
         /**Returns a reference to the HTML <thead> element. */


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17863113/202151447-13511658-9a21-49ad-aa72-aa5ff22c803b.png)
Allows element to be passed to constructor instead of selector just as implementation and documented behaviour.
![image](https://user-images.githubusercontent.com/17863113/202151630-36c726a5-ef5b-4ba2-8ed8-d8eea8dc9bea.png)


![image](https://user-images.githubusercontent.com/17863113/202152556-c30aad4d-b3e6-4495-987a-751823a57c18.png)

