### PR TITLE
Made render in ColumOption optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -199,7 +199,7 @@ declare module "simple-datatables"{
 
             }
          */
-        render(callback : render):any;
+        render?(callback : render):any;
 
     }
     type render =  (data : string,cell: Object,row:Object,) => void;


### PR DESCRIPTION
We are getting typescript errors regarding the columnsoptions: 

According to the index.d.ts the `render`  property is not optional in the ColumnOption. But this should be optional, right? 

https://github.com/fiduswriter/Simple-DataTables/blob/d1352cf5960678b8c4db11c1a98f70f4ae91fbde/index.d.ts#L202