### PR TITLE
Update package.json - build_css

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "npm run build_js && npm run build_js_umd && npm run build_css && npm run build_docs",
     "build_js": "rollup -c",
     "build_js_umd": "browserify dist/index.js --standalone simpleDatatables -o dist/umd/simple-datatables.js",
-    "build_css": "cp -R src/css dist/",
+    "build_css": "cp -R src/css/ dist/",
     "build_docs": "npm run build_docs_js && cp -R src/css docs/dist/",
     "build_docs_js": "rollup -c rollup.docs.config.mjs",
     "postbuild_docs": "cp -r dist/umd/simple-datatables.js docs/dist/umd.js",


### PR DESCRIPTION
This is the reason for all open CSS related issues since v5.0.0 until now, because `cp -R src/css dist/` copies the `css` folder inside the `dist` folder (so you created a new folder `css` inside the `dist` folder since v5.0.0 without replacing the `dist/style.css`), with this PR instead the contents of `css` are copied to the `dist` folder (so the `dist/style.css` will be replaced).

P.S.
Please delete the `css` folder from the `dist` folder on your local machine as it is no longer needed and it will disappear from the release.


For older versions since v5.0.0 till now the only possible solution is to replace the CSS import path `https://cdn.jsdelivr.net/npm/simple-datatables@v#.#.#/dist/style.css` with `https://cdn.jsdelivr.net/npm/simple-datatables@v#.#.#/dist/css/style.css`.