### PR TITLE
Update datatable.ts, moving isSplitQueryWord to only check the column setting once

### DIFF
--- a/src/datatable.ts
+++ b/src/datatable.ts
@@ -772,7 +772,15 @@ export class DataTable {
                 if (ignorePunctuation) {
                     columnQuery = columnQuery.replace(/[.,/#!$%^&*;:{}=-_`~()]/g, "")
                 }
-                return columnQuery
+                const isSplitQueryWord = column.isSplitQueryWord
+                const searchQuerySeparator = column.searchQuerySeparator
+                let columnQueryArr = []
+                if (isSplitQueryWord) {
+                    columnQueryArr = columnQuery.split(searchQuerySeparator)
+                } else {
+                    columnQueryArr.push(columnQuery)
+                } 
+                return columnQueryArr.filter(queryWord => queryWord)
             }
         )
         )
@@ -799,7 +807,7 @@ export class DataTable {
                 queryWords.every(
                     queries => queries.find(
                         (query, index) => query ?
-                            (this.columns.settings[index].isSplitQueryWord ? query.split(this.columns.settings[index].searchQuerySeparator) : [query]).find(queryWord => searchRow[index].includes(queryWord.trim())) :
+                            query.find(queryWord => searchRow[index].includes(queryWord)) :
                             false
                     )
                 )


### PR DESCRIPTION
Currently the `isSplitQueryWord` attribute as a column search option is being checked every time the data in a row is parsed. This could be more efficient by moving it to the location where all other column search options are parsed. In addition it returns an array which can later be used when searching for multiple values in one row in an AND manner.