### PR TITLE
Docs for classes

### DIFF
--- a/docs/documentation/API.md
+++ b/docs/documentation/API.md
@@ -31,7 +31,7 @@ Returns a reference to the currently displayed pagers.
 ### options
 #### type `Object`
 
-Returns the current configuration options.
+Returns the current configuration options.  See [Options](Options)
 
 ---
 

--- a/docs/documentation/Options.md
+++ b/docs/documentation/Options.md
@@ -15,6 +15,7 @@ let dataTable = new DataTable(myTable, options);
 * [type](columns#type)
 * [format](columns#format)
 ### Appearance
+* [classes](classes)
 * [columns](columns)
 * [fixedColumns](fixedColumns)
 * [fixedHeight](fixedHeight)


### PR DESCRIPTION
I noticed there were no hyperlinks to get to the documentation page on the configurable classes so I added it to the Options > Appearance section.  I also added a hyperlink from the property for `options` to the Options page.

Of note, I setup GitHub Pages on my fork and the "Run npm test" failed.  Not sure if that's something you see as well in your repo but thought I'd mention it.  The error output is below:

<details>
<summary>Run npm test output</summary>

```
> simple-datatables@7.3.0 test
> mocha

Selenium Manager binary found at /home/runner/work/simple-datatables/simple-datatables/node_modules/selenium-webdriver/bin/linux/selenium-manager
Driver path: /home/runner/work/simple-datatables/simple-datatables/node_modules/chromedriver/lib/chromedriver/chromedriver
Browser path: "/usr/bin/google-chrome-stable"
Server listening on port 3000.

WebDriverError: unknown error: no chrome binary at "/usr/bin/google-chrome-stable"
    at Object.throwDecodedError (/home/runner/work/simple-datatables/simple-datatables/node_modules/selenium-webdriver/lib/error.js:52[4](https://github.com/kczx3/simple-datatables/actions/runs/5751049761/job/15589028728#step:5:5):1[5](https://github.com/kczx3/simple-datatables/actions/runs/5751049761/job/15589028728#step:5:6))
    at parseHttpResponse (/home/runner/work/simple-datatables/simple-datatables/node_modules/selenium-webdriver/lib/http.js:[6](https://github.com/kczx3/simple-datatables/actions/runs/5751049761/job/15589028728#step:5:7)01:13)
    at Executor.execute (/home/runner/work/simple-datatables/simple-datatables/node_modules/selenium-webdriver/lib/http.js:529:2[8](https://github.com/kczx3/simple-datatables/actions/runs/5751049761/job/15589028728#step:5:9))
    at process.processTicksAndRejections (node:internal/process/task_queues:[9](https://github.com/kczx3/simple-datatables/actions/runs/5751049761/job/15589028728#step:5:10)5:5)
Error: Process completed with exit code 1.
```
</details>