### PR TITLE
Preserve HTML cell attributes in rendered table

### DIFF
--- a/docs/documentation/pagerRender.md
+++ b/docs/documentation/pagerRender.md
@@ -1,4 +1,4 @@
-### `rowRender`
+### `pagerRender`
 #### Type: `boolean` \ `function(data, ul)`
 #### Default: `false`
 

--- a/src/datatable.ts
+++ b/src/datatable.ts
@@ -12,6 +12,7 @@ import {
     inputCellType,
     elementNodeType,
     renderOptions,
+    rowType,
     TableDataType
 } from "./types"
 import {DiffDOM, nodeToObj} from "diff-dom"
@@ -66,7 +67,7 @@ export class DataTable {
 
     _virtualPagerDOM: elementNodeType
 
-    pages: {row: cellType[], index: number}[][]
+    pages: rowType[][]
 
     _rect: {width: number, height: number}
 
@@ -287,16 +288,22 @@ export class DataTable {
         this.update(true)
     }
 
-    _renderTable(renderOptions: renderOptions ={}) {
+    _renderTable(renderOptions: renderOptions = {}) {
+        let rows: rowType[]
+        const isPaged = (this.options.paging || this._searchQueries.length || this.columns._state.filters.length) && this._currentPage && this.pages.length && !renderOptions.noPaging
+        if (isPaged) {
+            rows = this.pages[this._currentPage - 1]
+        } else {
+            rows = this.data.data.map((row, index) => ({
+                row,
+                index
+            }))
+        }
+
         let newVirtualDOM = dataToVirtualDOM(
             this._tableAttributes,
             this.data.headings,
-            (this.options.paging || this._searchQueries.length || this.columns._state.filters.length) && this._currentPage && this.pages.length && !renderOptions.noPaging ?
-                this.pages[this._currentPage - 1] :
-                this.data.data.map((row, index) => ({
-                    row,
-                    index
-                })),
+            rows,
             this.columns.settings,
             this.columns._state,
             this.rows.cursor,
@@ -702,7 +709,7 @@ export class DataTable {
     }
 
     _paginate() {
-        let rows = this.data.data.map((row, index) => ({
+        let rows: rowType[] = this.data.data.map((row, index) => ({
             row,
             index
         }))
@@ -730,7 +737,7 @@ export class DataTable {
         if (this.options.paging && this.options.perPage > 0) {
             // Check for hidden columns
             this.pages = rows
-                .map((row: {row: cellType[], index: number}, i: number) => i % this.options.perPage === 0 ? rows.slice(i, i + this.options.perPage) : null)
+                .map((_row, i: number) => i % this.options.perPage === 0 ? rows.slice(i, i + this.options.perPage) : null)
                 .filter((page: {row: cellType[], index: number}[]) => page)
         } else {
             this.pages = [rows]

--- a/src/read_data.ts
+++ b/src/read_data.ts
@@ -83,8 +83,8 @@ const readDOMDataCell = (cell: HTMLElement, columnSettings : columnSettingsType)
         const data = !["false", "0", "null", "undefined"].includes(cell.innerText.toLowerCase().trim())
         cellData = {
             data,
-            order: data ? 1 : 0,
-            text: data ? "1" : "0"
+            text: data ? "1" : "0",
+            order: data ? 1 : 0
         }
         break
     }
@@ -97,6 +97,14 @@ const readDOMDataCell = (cell: HTMLElement, columnSettings : columnSettingsType)
         }
         break
     }
+    }
+
+    // Save cell attributes to reference when rendering
+    cellData.attributes = {}
+    if (cell.attributes) {
+        for (const attr of cell.attributes) {
+            cellData.attributes[attr.name] = attr.value
+        }
     }
 
     return cellData
@@ -136,7 +144,7 @@ export const readHeaderCell = (cell: inputHeaderCellType) : headerCellType => {
 
 export const readDOMHeaderCell = (cell: HTMLElement) : headerCellType => {
     const node = nodeToObj(cell, {valueDiffing: false})
-    let cellData
+    let cellData: headerCellType
     if (node.childNodes && (node.childNodes.length !== 1 || node.childNodes[0].nodeName !== "#text")) {
         cellData = {
             data: node.childNodes,
@@ -149,6 +157,10 @@ export const readDOMHeaderCell = (cell: HTMLElement) : headerCellType => {
             type: "string"
         }
     }
+
+    // Save header cell attributes to reference when rendering
+    cellData.attributes = node.attributes
+
     return cellData
 
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ interface cellType {
     data: string | number | boolean | elementNodeType[] | object;
     text?: string;
     order?: string | number;
+    attributes?: { [key: string]: string };
 }
 
 type inputCellType = cellType | string | number | boolean;
@@ -32,6 +33,7 @@ interface headerCellType {
     data: string | number | boolean | elementNodeType[] | object;
     type?: ("html" | "string");
     text?: string;
+    attributes?: { [key: string]: string };
 }
 
 type inputHeaderCellType = headerCellType | string | number | boolean;
@@ -48,6 +50,11 @@ interface TableDataType{
 }
 
 type renderType = ((cellData: (string | number | boolean | object | elementNodeType[]), td: object, rowIndex: number, cellIndex: number) => elementNodeType | string | void);
+
+interface rowType {
+    row: cellType[];
+    index: number;
+}
 
 export type DeepPartial<T> = T extends Function ? T : (T extends object ? { [P in keyof T]?: DeepPartial<T[P]>; } : T); // eslint-disable-line @typescript-eslint/ban-types
 // Source https://gist.github.com/navix/6c25c15e0a2d3cd0e5bce999e0086fc9
@@ -479,6 +486,7 @@ export {
     renderOptions,
     renderType,
     rowRenderType,
+    rowType,
     columnSettingsType,
     TableDataType,
     textNodeType


### PR DESCRIPTION
Preserves attributes from the HTML table headers (`<th>`) or cells (`<td>`) in the rendered datatable.

See the following example for a practical use case. Note the attributes in the `<th>` and `<td>` elements.

```html
<table id="example-table">
    <thead>
        <tr>
            <th class="name">Name</th> <!-- header with custom class -->
            <th>City</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td style="background-color: yellow;">Unity Pugh</td> <!-- cell with custom colour -->
            <td>Curicó</td>
        </tr>
        <tr>
            <td>Theodore Duran</td>
            <td>Dhanbad</td>
        </tr>
    </tbody>
</table>

<script>
    const dt = new DataTable("example-table");
</script>
```