### PR TITLE
Fixes footers and captions disappearing on empty tables

### DIFF
--- a/src/datatable.ts
+++ b/src/datatable.ts
@@ -1058,6 +1058,9 @@ export class DataTable {
             ]
         }
 
+        this._tableFooters.forEach(footer => newVirtualDOM.childNodes.push(footer))
+        this._tableCaptions.forEach(caption => newVirtualDOM.childNodes.push(caption))
+
         newVirtualDOM.attributes.class = newVirtualDOM.attributes.class ? `${newVirtualDOM.attributes.class} ${this.options.classes.table}` : this.options.classes.table
 
         if (this.options.tableRender) {

--- a/test/cases/empty-table-with-footer.html
+++ b/test/cases/empty-table-with-footer.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <link rel="stylesheet" href="../dist/css/style.css">
+        <title>empty-table-with-footer</title>
+    </head>
+    <body>
+        <table>
+            <caption>This is a table caption.</caption>
+            <thead>
+                <tr>
+                    <th>Header 1</th>
+                    <th>Header 2</th>
+                </tr>
+            </thead>
+            <tbody>
+                <!-- No data! -->
+            </tbody>
+            <tfoot>
+                <tr>
+                    <td colspan="2">
+                        This is a table footer.
+                    </td>
+                </tr>
+            </tfoot>
+        </table>
+
+        <script src="../dist/umd.js"></script>
+        <script>
+        window.dt = new window.simpleDatatables.DataTable("table")
+    </script>
+    </body>
+</html>

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -4,6 +4,7 @@ import express from "express"
 const app = express()
 
 app.use(express.static("docs/demos"))
+app.use("/tests", express.static("test/cases"))
 app.get("/documentation", (_req, res) => res.send("It's me, the documentation page!"))
 app.use("/favicon.ico", express.static("docs/favicon.ico"))
 app.use("/favicon.svg", express.static("docs/favicon.svg"))

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -22,9 +22,10 @@ if (process.env.CI) { // eslint-disable-line no-process-env
 const driver = new webdriver.Builder().withCapabilities(webdriver.Capabilities.chrome()).setChromeOptions(options).build()
 const manage = driver.manage()
 manage.window().maximize()
+const baseUrl = `http://localhost:${port}/`
 let demoUrls
 server.listen(port)
-await driver.get(`http://localhost:${port}`).then(
+await driver.get(baseUrl).then(
     () => driver.findElements(webdriver.By.css("a"))
 ).then(
     nodes => Promise.all(nodes.map(node => node.getAttribute("href")))
@@ -71,6 +72,54 @@ describe("Demos work", function() {
     ).then(
         log => assert.deepEqual(log, [])
     ))
+})
+
+describe("Integration tests pass", function() {
+    this.timeout(5000)
+
+    it("initializes the datatable", async () => {
+        await driver.get(`${baseUrl}1-simple/`)
+        const wrapper = await driver.findElement(webdriver.By.className("datatable-wrapper"))
+        const container = await wrapper.findElement(webdriver.By.className("datatable-container"))
+        const table = await container.findElement(webdriver.By.tagName("table"))
+        const tableClass = await table.getAttribute("class")
+        assert.equal(tableClass, "datatable-table", "table is missing class 'datatable-table'")
+
+        await wrapper.findElement(webdriver.By.className("datatable-top"))
+        await wrapper.findElement(webdriver.By.className("datatable-bottom"))
+    })
+
+    it("shows table footer", async () => {
+        await driver.get(`${baseUrl}24-footer`)
+        const table = await driver.findElement(webdriver.By.tagName("table"))
+        const tfoot = table.findElement(webdriver.By.tagName("tfoot"))
+        const tfootText = await tfoot.getText()
+        assert.equal(tfootText, "This is a table footer.")
+    })
+
+    it("shows table caption", async () => {
+        await driver.get(`${baseUrl}24-footer`)
+        const table = await driver.findElement(webdriver.By.tagName("table"))
+        const caption = table.findElement(webdriver.By.tagName("caption"))
+        const captionText = await caption.getText()
+        assert.equal(captionText, "This is a table caption.")
+    })
+
+    it("shows table footer when empty", async () => {
+        await driver.get(`${baseUrl}tests/empty-table-with-footer.html`)
+        const table = await driver.findElement(webdriver.By.tagName("table"))
+        const tfoot = table.findElement(webdriver.By.tagName("tfoot"))
+        const tfootText = await tfoot.getText()
+        assert.equal(tfootText, "This is a table footer.")
+    })
+
+    it("shows table caption when empty", async () => {
+        await driver.get(`${baseUrl}tests/empty-table-with-footer.html`)
+        const table = await driver.findElement(webdriver.By.tagName("table"))
+        const caption = table.findElement(webdriver.By.tagName("caption"))
+        const captionText = await caption.getText()
+        assert.equal(captionText, "This is a table caption.")
+    })
 })
 
 after(() => {


### PR DESCRIPTION
Custom table footers and captions were not being rendered on empty tables. The snippet bellow will render a datatable without the `<caption>` and `<tfoot>`.

This was my first time using Mocha. Please let me know if there's a better way to write the tests.

```html
<table>
    <caption>This is a table caption.</caption>
    <thead>
        <tr>
            <th>Header 1</th>
            <th>Header 2</th>
        </tr>
    </thead>
    <tbody>
        <!-- No data! -->
    </tbody>
    <tfoot>
        <tr>
            <td colspan="2">
                This is a table footer.
            </td>
        </tr>
    </tfoot>
</table>
<script>
    new window.simpleDatatables.DataTable("table")
</script>
```