### PR TITLE
Fix row display issue by replacing `datatable.rows.add(newRows)` with `dataTable.insert({data: newRows})`

### DIFF
--- a/docs/documentation/Dynamically-adding-data.md
+++ b/docs/documentation/Dynamically-adding-data.md
@@ -20,7 +20,7 @@ let newRows = [
     ...
 ];
 
-datatable.rows.add(newRows);
+datatable.insert({ data: newRows });
 ```
 ---
 


### PR DESCRIPTION
### Summary

The current implementation `datatable.rows.add(newRows);` causes an issue where the rows do not display, although the `.datatable-bottom` still shows the correct number of entries. To fix this, I have replaced it with `dataTable.insert({data: newRows})`, which successfully displays the rows as expected.

### Details

- **Issue**: The `datatable.rows.add(newRows);` method does not display the rows, even though the correct number of entries is shown in the `.datatable-bottom`.
- **Solution**: Changing the method to `dataTable.insert({data: newRows})` resolves the issue and ensures the rows are displayed correctly.

This issue is also documented in [issue #333](https://github.com/fiduswriter/simple-datatables/issues/333#issuecomment-1727388001).
