### PR TITLE
fix: inherit font-family on buttons

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -153,6 +153,7 @@
     background-color: inherit;
     cursor: pointer;
     text-align: inherit;
+    font-family: inherit;
     font-weight: inherit;
     font-size: inherit;
 }


### PR DESCRIPTION
While loading simple-datatables in a page, I noticed the font from the header row was slightly different. This was because simple-datatables adds buttons to make the columns sortable, and buttons don't inherit font settings by default. That means that if the page sets a font to the body tag, this won't be automatically inherited in the header row (unlike it would happen by default in a table)