### PR TITLE
Add debouncing to resize event to optimize resize performance

### DIFF
--- a/src/datatable.ts
+++ b/src/datatable.ts
@@ -29,6 +29,7 @@ import {Rows} from "./rows"
 import {Columns} from "./columns"
 import {defaultConfig} from "./config"
 import {createVirtualPagerDOM} from "./virtual_pager_dom"
+import {debounce} from "./editing/helpers"
 
 
 export class DataTable {
@@ -658,16 +659,15 @@ export class DataTable {
     }
 
     /**
-     * execute on resize
+     * execute on resize and debounce to avoid multiple calls
      */
-    _onResize() {
+    _onResize = debounce(() => {
         this._rect = this.containerDOM.getBoundingClientRect()
         if (!this._rect.width) {
-            // No longer shown, likely no longer part of DOM. Give up.
             return
         }
         this.update(true)
-    }
+    }, 100)
 
     /**
      * Destroy the instance


### PR DESCRIPTION
Hey guys,
with a lot of data inside the table and resizing the window, everything gets slowly because the resize event triggers multiple times and data-tables is relayouting all cells, even if they are not shown. A Quickfix of this is to add a debounce function to the resize event. This should improve the resizing performance.

Greets,
Till