### PR TITLE
Docs: Fixed case - `datatable` to `dataTable`

### DIFF
--- a/docs/documentation/rows-API.md
+++ b/docs/documentation/rows-API.md
@@ -19,7 +19,7 @@ Add new row data to the current instance. The `data` parameter must be an `array
 ```javascript
 let newRow = ["column1", "column2", "column3", "column4", ...];
 
-datatable.rows.add(newRow);
+dataTable.rows.add(newRow);
 
 ```
 
@@ -34,7 +34,7 @@ let newRows = [
     ...
 ];
 
- datatable.insert({data: newRows})
+ dataTable.insert({data: newRows})
  ```
 
 ---
@@ -44,7 +44,7 @@ let newRows = [
 Remove existing rows from the current instance. The `select` parameter can either be an `integer` or `array` of `integers` representing the row indexes.
 
 ```javascript
-let rows = datatable.rows;
+let rows = dataTable.rows;
 
 // remove the 6th row
 rows.remove(5);
@@ -61,10 +61,10 @@ For example, if you're trying to remove a row that's unrendered, the `rowIndex` 
 Another example would be if you're currently on page 5 and you have `perPage` set to `5` the currently rendered rows have a `rowIndex` of `0`, `1`, `2`, `3` and `4`, respectively, but to remove them you would need to use the indexes `20`, `21`, `22`, `23` and `24`, respectively.
 
 ```javascript
-let rows = datatable.rows;
+let rows = dataTable.rows;
 
 // Switch to page 5
-datatable.page(5);
+dataTable.page(5);
 
 // WRONG: removes the first 5 rows on page 1
 rows.remove([0, 1, 2, 3, 4]);
@@ -77,10 +77,10 @@ You can quickly access the correct index for the rendered row by grabbing it's `
 
 ```javascript
 // Get the first rendered row
-let rowToRemove = datatable.body.querySelector("tr");
+let rowToRemove = dataTable.body.querySelector("tr");
 
 // Remove it
-datatable.rows.remove(parseInt(rowToRemove.dataset.index));
+dataTable.rows.remove(parseInt(rowToRemove.dataset.index));
 
 ```
 


### PR DESCRIPTION
Updated the docs to match the correct case. Changed  `datatable` to `dataTable`