### PR TITLE
Fix `on` and `off` custom events listener types

### DIFF
--- a/src/datatable.ts
+++ b/src/datatable.ts
@@ -1134,7 +1134,7 @@ export class DataTable {
     /**
      * Add custom event listener
      */
-    on(event: string, callback: () => void) {
+    on(event: string, callback: (...args: any[]) => void) {
         this._events[event] = this._events[event] || []
         this._events[event].push(callback)
     }
@@ -1142,7 +1142,7 @@ export class DataTable {
     /**
      * Remove custom event listener
      */
-    off(event: string, callback: () => void) {
+    off(event: string, callback: (...args: any[]) => void) {
         if (event in this._events === false) return
         this._events[event].splice(this._events[event].indexOf(callback), 1)
     }


### PR DESCRIPTION
#### Typescript compiler error

```
Argument of type '(cursorIndex: number, event: MouseEvent) => void' is not assignable to parameter of type '() => void'. Target signature provides too few arguments. Expected 2 or more, but got 0. ts-plugin(2345)
```

#### How to reproduce

`dataTable.on('datatable.selectrow', (cursorIndex: number, event: MouseEvent) => {...})`
