### PR TITLE
handle colspan in CSV export

### DIFF
--- a/docs/demos/11-export/index.html
+++ b/docs/demos/11-export/index.html
@@ -40,16 +40,14 @@
                     <td>37%</td>
                 </tr>
                 <tr>
-                    <td>Theodore Duran</td>
-                    <td>8971</td>
+                    <td colspan="2">Theodore Duran</td>
+
                     <td>Dhanbad</td>
                     <td>1999/04/07</td>
                     <td>97%</td>
                 </tr>
                 <tr>
-                    <td>Kylie Bishop</td>
-                    <td>3147</td>
-                    <td>Norman</td>
+                    <td colspan="3">Kylie Bishop</td>
                     <td>2005/09/08</td>
                     <td>63%</td>
                 </tr>


### PR DESCRIPTION
This change makes the CSV export plugin respect columns with a colspan set so the exported file columns match up appropriately.