### PR TITLE
Prevent duplicate class assignment for table attributes in DataTable

### DIFF
--- a/src/datatable.ts
+++ b/src/datatable.ts
@@ -452,7 +452,9 @@ export class DataTable {
 
             ]
         }
-        tableVirtualDOM.attributes.class = joinWithSpaces(tableVirtualDOM.attributes.class, this.options.classes.table)
+        if (!tableVirtualDOM.attributes.class.includes(this.options.classes.table)) {
+            tableVirtualDOM.attributes.class = joinWithSpaces(tableVirtualDOM.attributes.class, this.options.classes.table)
+        }
         if (this.options.tableRender) {
             const renderedTableVirtualDOM : (elementNodeType | void) = this.options.tableRender(this.data, tableVirtualDOM, "header")
             if (renderedTableVirtualDOM) {
@@ -1103,7 +1105,9 @@ export class DataTable {
         this._tableFooters.forEach(footer => newVirtualDOM.childNodes.push(footer))
         this._tableCaptions.forEach(caption => newVirtualDOM.childNodes.push(caption))
 
-        newVirtualDOM.attributes.class = joinWithSpaces(newVirtualDOM.attributes.class, this.options.classes.table)
+        if (!newVirtualDOM.attributes.class.includes(this.options.classes.table)) {
+            newVirtualDOM.attributes.class = joinWithSpaces(newVirtualDOM.attributes.class, this.options.classes.table)
+        }
 
         if (this.options.tableRender) {
             const renderedTableVirtualDOM : (elementNodeType | void) = this.options.tableRender(this.data, newVirtualDOM, "message")


### PR DESCRIPTION
<img width="1080" alt="Screenshot 2025-03-29 at 00 59 31" src="https://github.com/user-attachments/assets/bd0b2849-9c42-4dfa-b579-cd0777a97b6e" />


How to reproduce:
- Observe the class of the table
- Search something that does not exist, which shows the `No results match your search query` page
- remove the search query
- Observe the class of the table again