### PR TITLE
feat(a11y): improve screen reader and keyboard accessibility

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -72,7 +72,8 @@ export const defaultConfig: DataTableConfiguration = {
         pageTitle: "Page {page}", // page label used in Aria-label
         noRows: "No entries found", // Message shown when there are no records to show
         noResults: "No results match your search query", // Message shown when there are no search results
-        info: "Showing {start} to {end} of {rows} entries" //
+        info: "Showing {start} to {end} of {rows} entries", //
+        sortHint: "Activate to sort" // Screen reader hint for sortable columns
     },
 
     // Customise the layout

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,7 @@ export const defaultConfig: DataTableConfiguration = {
     labels: {
         placeholder: "Search...", // The search input placeholder
         searchTitle: "Search within table", // The search input title
+        searchLabel: "Search", // Label for the search input
         perPage: "entries per page", // per-page dropdown label
         pageTitle: "Page {page}", // page label used in Aria-label
         noRows: "No entries found", // Message shown when there are no records to show
@@ -103,6 +104,7 @@ export const defaultConfig: DataTableConfiguration = {
         paginationListItem: "datatable-pagination-list-item",
         paginationListItemLink: "datatable-pagination-list-item-link",
         search: "datatable-search",
+        searchLabel: "datatable-search-label",
         selector: "datatable-selector",
         sorter: "datatable-sorter",
         table: "datatable-table",

--- a/src/datatable.ts
+++ b/src/datatable.ts
@@ -437,6 +437,19 @@ export class DataTable {
         this._virtualPagerDOM = newPagerVirtualDOM
     }
 
+    /**
+     * Focus the active page button after re-render.
+     * Prevents focus loss when prev/next buttons are removed at page boundaries.
+     */
+    _focusActivePageButton() {
+        const activeLi = this.wrapperDOM.querySelector(`.${this.options.classes.paginationListItem}.${this.options.classes.active}`)
+        if (!activeLi) return
+        const button = activeLi.querySelector("button, [data-page]")
+        if (button instanceof HTMLElement) {
+            button.focus()
+        }
+    }
+
     // Render header that is not in the same table element as the remainder
     // of the table. Used for tables with scrollY.
     _renderSeparateHeader() {
@@ -953,6 +966,10 @@ export class DataTable {
 
         this._renderPage(lastRowCursor)
         this._renderPagers()
+
+        if (this.onFirstPage || this.onLastPage) {
+            this._focusActivePageButton()
+        }
 
         this.emit("datatable.page", page)
     }

--- a/src/datatable.ts
+++ b/src/datatable.ts
@@ -72,6 +72,8 @@ export class DataTable {
 
     _pagerDOMs: HTMLElement[]
 
+    _pagerContainers: HTMLElement[]
+
     _virtualPagerDOM: elementNodeType
 
     pages: rowType[][]
@@ -233,6 +235,7 @@ export class DataTable {
         this.containerDOM = this.wrapperDOM.querySelector(containerSelector)
 
         this._pagerDOMs = []
+        this._pagerContainers = []
         const paginationSelector = classNamesToSelector(this.options.classes.pagination)
         Array.from(this.wrapperDOM.querySelectorAll(paginationSelector)).forEach(el => {
             if (!(el instanceof HTMLElement)) {
@@ -241,6 +244,7 @@ export class DataTable {
             // We remove the inner part of the pager containers to ensure they are all the same.
             el.innerHTML = `<ul class="${this.options.classes.paginationList}"></ul>`
             this._pagerDOMs.push(el.firstElementChild as HTMLElement)
+            this._pagerContainers.push(el)
         })
 
         this._virtualPagerDOM = {
@@ -416,10 +420,18 @@ export class DataTable {
             }
         }
 
+        const hasPagerItems = newPagerVirtualDOM.childNodes.length > 0
         const diffs = this._dd.diff(this._virtualPagerDOM, newPagerVirtualDOM)
-        // We may have more than one pager
-        this._pagerDOMs.forEach((pagerDOM: HTMLElement) => {
+
+        this._pagerDOMs.forEach((pagerDOM: HTMLElement, i: number) => {
             this._dd.apply(pagerDOM, diffs)
+            if (!hasPagerItems) {
+                if (pagerDOM.parentNode) {
+                    pagerDOM.parentNode.removeChild(pagerDOM)
+                }
+            } else if (!pagerDOM.parentNode) {
+                this._pagerContainers[i].appendChild(pagerDOM)
+            }
         })
 
         this._virtualPagerDOM = newPagerVirtualDOM

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -12,7 +12,10 @@ export const layoutTemplate = (options, dom) => `<div class='${options.classes.t
     ${
     options.searchable ?
         `<div class='${options.classes.search}'>
-            <input class='${options.classes.input}' placeholder='${options.labels.placeholder}' type='search' name="search" title='${options.labels.searchTitle}'${dom.id ? ` aria-controls="${dom.id}"` : ""}>
+            <label class='${options.classes.searchLabel}'>
+                ${options.labels.searchLabel}
+                <input class='${options.classes.input}' placeholder='${options.labels.placeholder}' type='search' name="search" title='${options.labels.searchTitle}'${dom.id ? ` aria-controls="${dom.id}"` : ""}>
+            </label>
         </div>` :
         ""
 }

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -17,7 +17,9 @@ export const layoutTemplate = (options, dom) => `<div class='${options.classes.t
         ""
 }
 </div>
-<div class='${options.classes.container}'${options.scrollY.length ? ` style='height: ${options.scrollY}; overflow-Y: auto;'` : ""}></div>
+<div class='${options.classes.container}'${options.scrollY.length ? ` style='height: ${options.scrollY}; overflow-Y: auto;'` : ""}>
+    ${options.sortable ? `<p hidden id="sort-hint">${options.labels.sortHint}</p>` : ""}
+</div>
 <div class='${options.classes.bottom}'>
     ${
     options.paging ?

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,6 +157,11 @@ interface LabelsConfiguration {
      * default: 'Search within table'
      * Sets the title of the search input.
      */
+    searchLabel: string;
+    /**
+     * default: 'Search'
+     * Sets the label for the search input.
+     */
     perPage: string;
     /**
      * default: 'entries per page'
@@ -220,6 +225,7 @@ interface ClassConfiguration {
     paginationListItem: string;
     paginationListItemLink: string;
     search: string;
+    searchLabel: string;
     selector: string;
     sorter: string;
     table: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,6 +181,11 @@ interface LabelsConfiguration {
      */
     info: string;
     /**
+     * default: 'Activate to sort'
+     * Screen reader hint indicating that the column is sortable
+     */
+    sortHint: string;
+    /**
      * default: 'Showing {start} to {end} of {rows} entries'
      * Displays current range, page number, etc
      *

--- a/src/virtual_dom.ts
+++ b/src/virtual_dom.ts
@@ -87,9 +87,13 @@ export const headingsToVirtualHeaderRowDOM = (
                             [
                                 {
                                     nodeName: "BUTTON",
-                                    attributes: {
-                                        class: column.filter ? classes.filter : classes.sorter
-                                    },
+                                    attributes:
+                                        column.filter ?
+                                            {class: classes.filter} :
+                                            {
+                                                class: classes.sorter,
+                                                "aria-describedby": "sort-hint"
+                                            },
                                     childNodes: headerNodes
                                 }
                             ]

--- a/src/virtual_pager_dom.ts
+++ b/src/virtual_pager_dom.ts
@@ -42,7 +42,8 @@ const truncate = (paginationListItems: elementNodeType[], currentPage: number, p
                         {
                             nodeName: "BUTTON",
                             attributes: {
-                                class: classes.paginationListItemLink
+                                class: classes.paginationListItemLink,
+                                "aria-hidden": "true"
                             },
                             childNodes: [
                                 {
@@ -64,7 +65,7 @@ const truncate = (paginationListItems: elementNodeType[], currentPage: number, p
 }
 
 
-const paginationListItem = (page: number, label: string, options: DataTableConfiguration, state: {active?: boolean, hidden?: boolean} = {}) : elementNodeType => ({
+const paginationListItem = (page: number, label: string, options: DataTableConfiguration, state: {active?: boolean, hidden?: boolean} = {}, decorative = false) : elementNodeType => ({
     nodeName: "LI",
     attributes: {
         class:
@@ -83,10 +84,21 @@ const paginationListItem = (page: number, label: string, options: DataTableConfi
                 "aria-label": options.labels.pageTitle.replace("{page}", String(page))
             },
             childNodes: [
-                {
-                    nodeName: "#text",
-                    data: label
-                }
+                decorative ?
+                    {
+                        nodeName: "SPAN",
+                        attributes: {"aria-hidden": "true"},
+                        childNodes: [
+                            {
+                                nodeName: "#text",
+                                data: label
+                            }
+                        ]
+                    } :
+                    {
+                        nodeName: "#text",
+                        data: label
+                    }
             ]
         }
     ]
@@ -98,13 +110,13 @@ export const createVirtualPagerDOM = (onFirstPage: boolean, onLastPage: boolean,
 
     // first button
     if (options.firstLast) {
-        pagerListItems.push(paginationListItem(1, options.firstText, options))
+        pagerListItems.push(paginationListItem(1, options.firstText, options, {}, true))
     }
 
     // prev button
     if (options.nextPrev) {
         const prev = onFirstPage ? 1 : currentPage - 1
-        pagerListItems.push(paginationListItem(prev, options.prevText, options, {hidden: onFirstPage}))
+        pagerListItems.push(paginationListItem(prev, options.prevText, options, {hidden: onFirstPage}, true))
     }
 
     let pages = [...Array(totalPages).keys()].map(index => paginationListItem(index+1, String(index+1), options, {active: (index === (currentPage-1))}))
@@ -126,12 +138,12 @@ export const createVirtualPagerDOM = (onFirstPage: boolean, onLastPage: boolean,
     // next button
     if (options.nextPrev) {
         const next = onLastPage ? totalPages : currentPage + 1
-        pagerListItems.push(paginationListItem(next, options.nextText, options, {hidden: onLastPage}))
+        pagerListItems.push(paginationListItem(next, options.nextText, options, {hidden: onLastPage}, true))
     }
 
     // last button
     if (options.firstLast) {
-        pagerListItems.push(paginationListItem(totalPages, options.lastText, options))
+        pagerListItems.push(paginationListItem(totalPages, options.lastText, options, {}, true))
     }
 
     const pager : elementNodeType = {


### PR DESCRIPTION
This PR addresses issues found during an official accessibility audit of an application I worked on.
The fixes focus mainly on improving the experience for screen reader users and people navigating with a keyboard.
Some of these changes may seem unnecessary when looking only at specifications or documentation.
However, the audit surfaced real-world issues with certain "buggy" screen-readers.

### Changes

* **Add visible label to search input** (`d09f81c`)
  Wraps the search `<input>` in a `<label>` element with configurable text (`labels.searchLabel`, default `"Search"`). Also adds a `searchLabel` class for styling. This ensures the search field has a proper programmatic label.

* **Focus active page button at page boundaries** (`70dfcbe`)
  When navigating to the first or last page, the previous/next buttons are removed from the DOM, which can cause keyboard focus to be lost. After re-rendering pagers, focus is now moved to the active page number button when on a boundary page.

* **Remove pagination list from DOM when empty** (`9a17231`)
  When all pager items are hidden, for example in single-page tables or filtered results, the `<ul>` pagination list is removed from the DOM entirely and re-inserted when items reappear. This prevents screen readers from announcing an empty navigation region.

* **Add sort hint for sortable column buttons** (`32a217f`)
  Adds a hidden `<p id="sort-hint">` element and references it via `aria-describedby` on sortable column `<button>` elements. Screen readers announce "Activate to sort" when a column header receives focus, making it clear that the column is sortable. The hint text is configurable via `labels.sortHint`.

* **Hide decorative pager symbols from screen readers** (`0675124`)
  Wraps the text labels of first/previous/next/last buttons in `<span aria-hidden="true">`, and adds `aria-hidden="true"` to the ellipsis/truncation buttons. This prevents some screen readers from double-reading decorative symbols alongside the link's `aria-label`. This issue was identified during the official accessibility audit.